### PR TITLE
Fix a small bug of rotate_iou_gpu: the iou between two same boxes can be 0.

### DIFF
--- a/second/core/non_max_suppression/nms_gpu.py
+++ b/second/core/non_max_suppression/nms_gpu.py
@@ -323,7 +323,9 @@ def point_in_quadrilateral(pt_x, pt_y, corners):
     adad = ad0 * ad0 + ad1 * ad1
     adap = ad0 * ap0 + ad1 * ap1
 
-    return abab >= abap and abap >= 0 and adad >= adap and adap >= 0
+    #return abab >= abap and abap >= 0 and adad >= adap and adap >= 0
+    eps = -1e-6
+    return abab - abap >= eps and abap >= eps and adad - adap >= eps and adap >= eps
 
 
 @cuda.jit('(float32[:], float32[:], float32[:])', device=True, inline=True)

--- a/second/core/non_max_suppression/test_nms_gpu.py
+++ b/second/core/non_max_suppression/test_nms_gpu.py
@@ -1,0 +1,18 @@
+from nms_gpu  import rotate_iou_gpu_eval
+import numpy as np
+
+def main():
+  boxes = np.array([
+    [0, 0, 1,   2., 0.1],
+    [0, 0, .001,   2., 0.1],
+    [0, 0, 0.1, 2., 0.5],
+    [0, 0, 0.1, 2., -np.pi/2],
+    ])
+
+  ious = np.diag( rotate_iou_gpu_eval(boxes, boxes) )
+  print(f"ious: {ious}")
+  #old: [0.         0.         0.33333316 0.        ]
+  #new: [1.         0.99998605 0.99999934 1.        ]
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
 A test demo is provided in test_nms_gpu.py